### PR TITLE
fix heap run out of memory

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "react-scripts --max_old_space_size=8192 build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "prepare": "babel src --out-dir lib"


### PR DESCRIPTION
fixes `FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory` error when running `yarn build` (example: https://app.netlify.com/sites/stanforddaily-archives/deploys/5eb808fcdedac200061fe864)

https://stackoverflow.com/questions/53230823/fatal-error-ineffective-mark-compacts-near-heap-limit-allocation-failed-javas