### PR TITLE
Improve cloudsearch add fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "cross-fetch": "^3.0.2",
     "interactjs": "^1.4.3",
     "jsdom": "^16.0.1",
+    "lucene": "^2.1.1",
     "moment": "^2.24.0",
     "node-sass": "^4.13.1",
     "openseadragon": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "react-scripts --max_old_space_size=8192 build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "prepare": "babel src --out-dir lib"

--- a/src/__test__/search.test.js
+++ b/src/__test__/search.test.js
@@ -14,7 +14,7 @@ describe("createCloudsearchQuery", () => {
         article_type_advertisement: true,
       })
     ).toMatchInlineSnapshot(
-      `"q.parser=lucene&q=publish_date:[1892-01-01T12:00:00Z TO 2015-01-02T12:00:00Z] AND (article_type:article OR article_type:advertisement)"`
+      `"q=publish_date%3A%5B1892-01-01T12%3A00%3A00Z%20TO%202015-01-02T12%3A00%3A00Z%5D%20AND%20%28article_type%3Aarticle%20OR%20article_type%3Aadvertisement%29&q.parser=lucene"`
     );
   });
 
@@ -26,7 +26,7 @@ describe("createCloudsearchQuery", () => {
         article_type_article: true,
       })
     ).toMatchInlineSnapshot(
-      `"q.parser=lucene&q=publish_date:[1892-01-01T12:00:00Z TO 2015-01-02T12:00:00Z] AND (article_type:article)"`
+      `"q=publish_date%3A%5B1892-01-01T12%3A00%3A00Z%20TO%202015-01-02T12%3A00%3A00Z%5D%20AND%20%28article_type%3Aarticle%29&q.parser=lucene"`
     );
   });
 
@@ -39,7 +39,7 @@ describe("createCloudsearchQuery", () => {
         article_type_advertisement: false,
       })
     ).toMatchInlineSnapshot(
-      `"q.parser=lucene&q=publish_date:[1892-01-01T12:00:00Z TO 2015-01-02T12:00:00Z] AND (article_type:article)"`
+      `"q=publish_date%3A%5B1892-01-01T12%3A00%3A00Z%20TO%202015-01-02T12%3A00%3A00Z%5D%20AND%20%28article_type%3Aarticle%29&q.parser=lucene"`
     );
   });
 
@@ -72,7 +72,7 @@ describe("createCloudsearchQuery", () => {
         article_text: "test",
       })
     ).toMatchInlineSnapshot(
-      `"q.parser=lucene&q=article_text:test AND publish_date:[1892-01-01T12:00:00Z TO 2015-01-02T12:00:00Z] AND (article_type:article)"`
+      `"q=article_text%3Atest%20AND%20publish_date%3A%5B1892-01-01T12%3A00%3A00Z%20TO%202015-01-02T12%3A00%3A00Z%5D%20AND%20%28article_type%3Aarticle%29&q.parser=lucene"`
     );
   });
 
@@ -85,7 +85,7 @@ describe("createCloudsearchQuery", () => {
         author: "Firstname Lastname",
       })
     ).toMatchInlineSnapshot(
-      `"q.parser=lucene&q=author:\\"Firstname Lastname\\" AND publish_date:[1892-01-01T12:00:00Z TO 2015-01-02T12:00:00Z] AND (article_type:article)"`
+      `"q=author%3A%22Firstname%20Lastname%22%20AND%20publish_date%3A%5B1892-01-01T12%3A00%3A00Z%20TO%202015-01-02T12%3A00%3A00Z%5D%20AND%20%28article_type%3Aarticle%29&q.parser=lucene"`
     );
   });
 
@@ -98,7 +98,7 @@ describe("createCloudsearchQuery", () => {
         title: "TitleWord1 TitleWord2",
       })
     ).toMatchInlineSnapshot(
-      `"q.parser=lucene&q=publish_date:[1892-01-01T12:00:00Z TO 2015-01-02T12:00:00Z] AND title:\\"TitleWord1 TitleWord2\\" AND (article_type:article)"`
+      `"q=publish_date%3A%5B1892-01-01T12%3A00%3A00Z%20TO%202015-01-02T12%3A00%3A00Z%5D%20AND%20title%3A%22TitleWord1%20TitleWord2%22%20AND%20%28article_type%3Aarticle%29&q.parser=lucene"`
     );
   });
 
@@ -111,7 +111,7 @@ describe("createCloudsearchQuery", () => {
         author_title: "AUTHOR_TITLE",
       })
     ).toMatchInlineSnapshot(
-      `"q.parser=lucene&q=publish_date:[1892-01-01T12:00:00Z TO 2015-01-02T12:00:00Z] AND author_title:\\"AUTHOR_TITLE\\" AND (article_type:article)"`
+      `"q=publish_date%3A%5B1892-01-01T12%3A00%3A00Z%20TO%202015-01-02T12%3A00%3A00Z%5D%20AND%20author_title%3A%22AUTHOR_TITLE%22%20AND%20%28article_type%3Aarticle%29&q.parser=lucene"`
     );
   });
 
@@ -124,7 +124,7 @@ describe("createCloudsearchQuery", () => {
         resultsPerPage: 20,
       })
     ).toMatchInlineSnapshot(
-      `"q.parser=lucene&q=publish_date:[1892-01-01T12:00:00Z TO 2015-01-02T12:00:00Z] AND (article_type:article)&size=20"`
+      `"q=publish_date%3A%5B1892-01-01T12%3A00%3A00Z%20TO%202015-01-02T12%3A00%3A00Z%5D%20AND%20%28article_type%3Aarticle%29&q.parser=lucene&size=20"`
     );
   });
 
@@ -138,7 +138,7 @@ describe("createCloudsearchQuery", () => {
         resultsPerPage: 20,
       })
     ).toMatchInlineSnapshot(
-      `"q.parser=lucene&q=publish_date:[1892-01-01T12:00:00Z TO 2015-01-02T12:00:00Z] AND (article_type:article)&size=20&start=400"`
+      `"q=publish_date%3A%5B1892-01-01T12%3A00%3A00Z%20TO%202015-01-02T12%3A00%3A00Z%5D%20AND%20%28article_type%3Aarticle%29&q.parser=lucene&size=20&start=380"`
     );
   });
 
@@ -162,7 +162,7 @@ describe("createCloudsearchQuery", () => {
         highlight: "article_text",
       })
     ).toMatchInlineSnapshot(
-      `"q.parser=lucene&q=publish_date:[1892-01-01T12:00:00Z TO 2015-01-02T12:00:00Z] AND (article_type:article)&highlight.article_text=%7Bformat:'html',max_phrases:5%7D"`
+      `"highlight.article_text=%7Bformat%3A%27html%27%2Cmax_phrases%3A5%7D&q=publish_date%3A%5B1892-01-01T12%3A00%3A00Z%20TO%202015-01-02T12%3A00%3A00Z%5D%20AND%20%28article_type%3Aarticle%29&q.parser=lucene"`
     );
   });
 });

--- a/src/__test__/search.test.js
+++ b/src/__test__/search.test.js
@@ -1,0 +1,168 @@
+import { createCloudsearchQuery } from "../helpers/search";
+
+describe("createCloudsearchQuery", () => {
+  test("Empty Query, Error", () => {
+    expect(createCloudsearchQuery({})).toMatchInlineSnapshot(`undefined`);
+  });
+
+  test("Query for everything (empty form query i.e. default values)", () => {
+    expect(
+      createCloudsearchQuery({
+        year_start: 1892,
+        year_end: 2014,
+        article_type_article: true,
+        article_type_advertisement: true,
+      })
+    ).toMatchInlineSnapshot(
+      `"q.parser=lucene&q=publish_date:[1892-01-01T12:00:00Z TO 2015-01-02T12:00:00Z] AND (article_type:article OR article_type:advertisement)"`
+    );
+  });
+
+  test("Query for all articles (empty form query i.e. default values)", () => {
+    expect(
+      createCloudsearchQuery({
+        year_start: 1892,
+        year_end: 2014,
+        article_type_article: true,
+      })
+    ).toMatchInlineSnapshot(
+      `"q.parser=lucene&q=publish_date:[1892-01-01T12:00:00Z TO 2015-01-02T12:00:00Z] AND (article_type:article)"`
+    );
+  });
+
+  test("Another way to query for all articles (empty form query i.e. default values)", () => {
+    expect(
+      createCloudsearchQuery({
+        year_start: 1892,
+        year_end: 2014,
+        article_type_article: true,
+        article_type_advertisement: false,
+      })
+    ).toMatchInlineSnapshot(
+      `"q.parser=lucene&q=publish_date:[1892-01-01T12:00:00Z TO 2015-01-02T12:00:00Z] AND (article_type:article)"`
+    );
+  });
+
+  test("Must include either article_type_article or article_type_advertisement", () => {
+    expect(
+      createCloudsearchQuery({
+        year_start: 1892,
+        year_end: 2014,
+      })
+    ).toMatchInlineSnapshot(`undefined`);
+  });
+
+  test("At least one of article_type_article or article_type_advertisement must be true", () => {
+    expect(
+      createCloudsearchQuery({
+        year_start: 1892,
+        year_end: 2014,
+        article_type_article: false,
+        article_type_advertisement: false,
+      })
+    ).toMatchInlineSnapshot(`undefined`);
+  });
+
+  test("Search for article text", () => {
+    expect(
+      createCloudsearchQuery({
+        year_start: 1892,
+        year_end: 2014,
+        article_type_article: true,
+        article_text: "test",
+      })
+    ).toMatchInlineSnapshot(
+      `"q.parser=lucene&q=article_text:test AND publish_date:[1892-01-01T12:00:00Z TO 2015-01-02T12:00:00Z] AND (article_type:article)"`
+    );
+  });
+
+  test("Search for author", () => {
+    expect(
+      createCloudsearchQuery({
+        year_start: 1892,
+        year_end: 2014,
+        article_type_article: true,
+        author: "Firstname Lastname",
+      })
+    ).toMatchInlineSnapshot(
+      `"q.parser=lucene&q=author:\\"Firstname Lastname\\" AND publish_date:[1892-01-01T12:00:00Z TO 2015-01-02T12:00:00Z] AND (article_type:article)"`
+    );
+  });
+
+  test("Search for title", () => {
+    expect(
+      createCloudsearchQuery({
+        year_start: 1892,
+        year_end: 2014,
+        article_type_article: true,
+        title: "TitleWord1 TitleWord2",
+      })
+    ).toMatchInlineSnapshot(
+      `"q.parser=lucene&q=publish_date:[1892-01-01T12:00:00Z TO 2015-01-02T12:00:00Z] AND title:\\"TitleWord1 TitleWord2\\" AND (article_type:article)"`
+    );
+  });
+
+  test("Search for author title", () => {
+    expect(
+      createCloudsearchQuery({
+        year_start: 1892,
+        year_end: 2014,
+        article_type_article: true,
+        author_title: "AUTHOR_TITLE",
+      })
+    ).toMatchInlineSnapshot(
+      `"q.parser=lucene&q=publish_date:[1892-01-01T12:00:00Z TO 2015-01-02T12:00:00Z] AND author_title:\\"AUTHOR_TITLE\\" AND (article_type:article)"`
+    );
+  });
+
+  test("Search with results per page", () => {
+    expect(
+      createCloudsearchQuery({
+        year_start: 1892,
+        year_end: 2014,
+        article_type_article: true,
+        resultsPerPage: 20,
+      })
+    ).toMatchInlineSnapshot(
+      `"q.parser=lucene&q=publish_date:[1892-01-01T12:00:00Z TO 2015-01-02T12:00:00Z] AND (article_type:article)&size=20"`
+    );
+  });
+
+  test("Search starting at a page number", () => {
+    expect(
+      createCloudsearchQuery({
+        year_start: 1892,
+        year_end: 2014,
+        article_type_article: true,
+        pageNumber: 20,
+        resultsPerPage: 20,
+      })
+    ).toMatchInlineSnapshot(
+      `"q.parser=lucene&q=publish_date:[1892-01-01T12:00:00Z TO 2015-01-02T12:00:00Z] AND (article_type:article)&size=20&start=400"`
+    );
+  });
+
+  test("Error starting at a page number without knowing reuslts per page", () => {
+    expect(
+      createCloudsearchQuery({
+        year_start: 1892,
+        year_end: 2014,
+        article_type_article: true,
+        pageNumber: 20,
+      })
+    ).toMatchInlineSnapshot(`undefined`);
+  });
+
+  test("Search with highlights", () => {
+    expect(
+      createCloudsearchQuery({
+        year_start: 1892,
+        year_end: 2014,
+        article_type_article: true,
+        highlight: "article_text",
+      })
+    ).toMatchInlineSnapshot(
+      `"q.parser=lucene&q=publish_date:[1892-01-01T12:00:00Z TO 2015-01-02T12:00:00Z] AND (article_type:article)&highlight.article_text=%7Bformat:'html',max_phrases:5%7D"`
+    );
+  });
+});

--- a/src/helpers/search.js
+++ b/src/helpers/search.js
@@ -1,3 +1,6 @@
+import { STRINGS } from "../helpers/constants";
+import queryString from "query-string";
+
 export function createCloudsearchQuery(query){
     let query_string = "q=" + query.q;
 
@@ -32,4 +35,16 @@ export function createCloudsearchQuery(query){
     // }
     
     return query_string + fq;
+}
+
+export function getCloudsearchURL(formData) {
+    return STRINGS.ROUTE_CLOUDSEARCH_PREFIX + "?" + queryString.stringify(formData);
+}
+
+export function sendCloudsearchFromForm(event, history) {
+    const searchKeyword = event.target.elements.searchKeyword.value;
+    if (searchKeyword) {
+        history.push(getCloudsearchURL({ q: searchKeyword }));
+    }
+    event.preventDefault();
 }

--- a/src/helpers/search.js
+++ b/src/helpers/search.js
@@ -3,24 +3,35 @@ import lucene from "lucene"
 import queryString from "query-string";
 
 export const DEFAULTS_FORM_DATA = {
-    q: "",
+    article_text: "",
     year_start: 1892,
     year_end: 2014,
     page: 1,
     pagelen: 20,
     author: undefined,
+    title: undefined,
+    article_type_article: true,
+    article_type_advertisement: true,
   };
   
 function add_and_lucene_string(lucene_string, key, val){
     return ` ${lucene_string.length > 0 ? 'AND' : ''} ${key}:${val}`; 
+}
+
+function add_and_lucene_nested_string(lucene_string, string){
+    return ` ${lucene_string.length > 0 ? 'AND' : ''} (${string})`; 
+}
+
+function add_or_lucene_string(lucene_string, key, val){
+    return ` ${lucene_string.length > 0 ? 'OR' : ''} ${key}:${val}`; 
 }
   
 export function createCloudsearchQuery(query){
     try {
         let query_string = "q.parser=lucene&q=";
         let lucene_string = "";
-        if(query.q){
-            lucene_string += add_and_lucene_string(lucene_string, 'article_text', query.q);
+        if(query.article_text){
+            lucene_string += add_and_lucene_string(lucene_string, 'article_text', query.article_text);
         }
         if(query.author){
             lucene_string += add_and_lucene_string(lucene_string, 'author', query.author);
@@ -28,6 +39,20 @@ export function createCloudsearchQuery(query){
         if(query.year_start && query.year_end){
             lucene_string += add_and_lucene_string(lucene_string, 'publish_date', `[${query.year_start}-01-01T12:00:00Z TO ${query.year_end+1}-01-02T12:00:00Z]`);
         }
+        if(query.title){
+            lucene_string += add_and_lucene_string(lucene_string, 'title', query.title);
+        }
+        
+        let article_type_lucene_string = ""
+        if(query.article_type_article !== undefined && query.article_type_article){
+            article_type_lucene_string += add_or_lucene_string(article_type_lucene_string, 'article_type', 'article');
+        }
+        if(query.article_type_advertisement !== undefined && query.article_type_advertisement){
+            article_type_lucene_string += add_or_lucene_string(article_type_lucene_string, 'article_type', 'advertisement');
+        }
+
+        lucene_string += add_and_lucene_nested_string(lucene_string, article_type_lucene_string)
+
         const ast = lucene.parse(lucene_string);
         let lucene_query = lucene.toString(ast);
         query_string += lucene_query;
@@ -42,6 +67,7 @@ export function createCloudsearchQuery(query){
             query_string += `&highlight.article_text=%7Bformat:'html',max_phrases:5%7D`; //this nailed me for an hour: must encode '{' and '}'
         }
 
+        console.log(query_string);
         return query_string;
     } catch {
         return undefined;
@@ -55,7 +81,7 @@ export function getCloudsearchURL(formData) {
 export function sendCloudsearchFromForm(event, history) {
     const searchKeyword = event.target.elements.searchKeyword.value;
     if (searchKeyword) {
-        history.push(getCloudsearchURL({ q: searchKeyword }));
+        history.push(getCloudsearchURL({ article_text: searchKeyword }));
     }
     event.preventDefault();
 }

--- a/src/helpers/search.js
+++ b/src/helpers/search.js
@@ -67,7 +67,7 @@ export function createCloudsearchQuery(query){
             if(!query.resultsPerPage){
                 throw new Error("must have results per page if specifying page number");
             }
-            query_string += `&start=${query.resultsPerPage * query.pageNumber}`;
+            query_string += `&start=${query.resultsPerPage * (query.pageNumber-1)}`;
         }
         if(query.highlight === 'article_text'){
             query_string += `&highlight.article_text=%7Bformat:'html',max_phrases:5%7D`; //this nailed me for an hour: must encode '{' and '}'

--- a/src/helpers/search.js
+++ b/src/helpers/search.js
@@ -12,6 +12,7 @@ export const DEFAULTS_FORM_DATA = {
     title: undefined,
     article_type_article: true,
     article_type_advertisement: true,
+    author_title: undefined,
   };
   
 function add_and_lucene_string(lucene_string, key, val){
@@ -34,13 +35,15 @@ export function createCloudsearchQuery(query){
             lucene_string += add_and_lucene_string(lucene_string, 'article_text', query.article_text);
         }
         if(query.author){
-            lucene_string += add_and_lucene_string(lucene_string, 'author', query.author);
+            lucene_string += add_and_lucene_string(lucene_string, 'author', '"' + query.author + '"');
         }
         if(query.year_start && query.year_end){
             lucene_string += add_and_lucene_string(lucene_string, 'publish_date', `[${query.year_start}-01-01T12:00:00Z TO ${query.year_end+1}-01-02T12:00:00Z]`);
         }
         if(query.title){
-            lucene_string += add_and_lucene_string(lucene_string, 'title', query.title);
+            lucene_string += add_and_lucene_string(lucene_string, 'title', '"' + query.title + '"');
+        }if(query.author_title){
+            lucene_string += add_and_lucene_string(lucene_string, 'author_title', '"' + query.author_title + '"');
         }
         
         let article_type_lucene_string = ""

--- a/src/helpers/search.js
+++ b/src/helpers/search.js
@@ -64,15 +64,17 @@ export function createCloudsearchQuery(query){
             query_string += `&size=${query.resultsPerPage}`;
         }
         if(query.pageNumber){
+            if(!query.resultsPerPage){
+                throw new Error("must have results per page if specifying page number");
+            }
             query_string += `&start=${query.resultsPerPage * query.pageNumber}`;
         }
         if(query.highlight === 'article_text'){
             query_string += `&highlight.article_text=%7Bformat:'html',max_phrases:5%7D`; //this nailed me for an hour: must encode '{' and '}'
         }
-
         console.log(query_string);
         return query_string;
-    } catch {
+    } catch(error){
         return undefined;
     }
 }

--- a/src/pages/CloudsearchView.jsx
+++ b/src/pages/CloudsearchView.jsx
@@ -38,7 +38,7 @@ class CloudsearchView extends React.Component {
   }
 
   startSearchFromQuery() {
-    let { q, author, year_start, year_end, page, pagelen } = queryString.parse(
+    let { article_text, author, title, article_type_article, article_type_advertisement, year_start, year_end, page, pagelen } = queryString.parse(
       window.location.search
     );
     // https://stackoverflow.com/a/4564199/2603230
@@ -46,34 +46,37 @@ class CloudsearchView extends React.Component {
     year_end = Number(year_end) || DEFAULTS_FORM_DATA.year_end;
     page = Number(page) || DEFAULTS_FORM_DATA.page;
     pagelen = Number(pagelen) || DEFAULTS_FORM_DATA.pagelen;
+    article_type_article = article_type_article ? article_type_article === 'true' : DEFAULTS_FORM_DATA.article_type_article;
+    article_type_advertisement = article_type_advertisement ? article_type_advertisement === 'true' : DEFAULTS_FORM_DATA.article_type_advertisement;
     this.setState({
       loading: true,
       formData: {
-        q,
+        article_text,
         year_start,
         year_end,
         page,
         pagelen,
         author,
+        title,
+        article_type_article,
+        article_type_advertisement,
       }
     });
 
-    if (q || author || (year_start && year_end)) { // probably should just allow any
-      document.title =
-        "Search results for " + q + STRINGS.SITE_NAME_WITH_DIVIDER;
-      // TODO: make sure `page` (x>=1) and `pagelen` (1<=x<=1000) is number and within the acceptable range.
-      this.searchFor({
-        q,
-        year_start,
-        year_end,
-        resultsPerPage: pagelen,
-        pageNumber: page,
-        author
-      });
-    } else {
-      document.title = "Search" + STRINGS.SITE_NAME_WITH_DIVIDER;
-      this.setState({ loading: false });
-    }
+    document.title =
+      "Search results for " + article_text + STRINGS.SITE_NAME_WITH_DIVIDER;
+    // TODO: make sure `page` (x>=1) and `pagelen` (1<=x<=1000) is number and within the acceptable range.
+    this.searchFor({
+      article_text,
+      year_start,
+      year_end,
+      resultsPerPage: pagelen,
+      pageNumber: page,
+      author,
+      title,
+      article_type_article,
+      article_type_advertisement,
+    });
   }
 
   render() {
@@ -83,10 +86,20 @@ class CloudsearchView extends React.Component {
       type: "object",
       required: [],
       properties: {
-        q: {
-          title: "Keyword",
+        article_text: {
+          title: "Article Text",
           type: "string",
-          default: DEFAULTS_FORM_DATA.q
+          default: DEFAULTS_FORM_DATA.article_text
+        },
+        title: {
+          title: "Article Title",
+          type: "string",
+          default: DEFAULTS_FORM_DATA.title
+        },
+        author: {
+          title: "Author",
+          type: "string",
+          default: DEFAULTS_FORM_DATA.author
         },
         year_start: {
           title: "From",
@@ -100,10 +113,15 @@ class CloudsearchView extends React.Component {
           enum: range,
           default: DEFAULTS_FORM_DATA.year_end
         },
-        author: {
-          title: "Author",
-          type: "string",
-          default: DEFAULTS_FORM_DATA.author
+        article_type_article: {
+          title: " Articles",
+          type: "boolean",
+          default: DEFAULTS_FORM_DATA.article_type_article,
+        },
+        article_type_advertisement: {
+          title: " Advertisements",
+          type: "boolean",
+          default: DEFAULTS_FORM_DATA.article_type_advertisement,
         },
         /** Hidden properties **/
         page: {
@@ -121,10 +139,13 @@ class CloudsearchView extends React.Component {
     };
 
     const uiSchema = {
-      q: {
+      article_text: {
         "ui:placeholder": "Leave empty to search all"
       },
       author: {
+        "ui:placeholder": "Leave empty to search all"
+      },
+      title: {
         "ui:placeholder": "Leave empty to search all"
       },
       page: {
@@ -207,21 +228,27 @@ class CloudsearchView extends React.Component {
   }
 
   searchFor({
-    q,
+    article_text,
     year_start,
     year_end,
     resultsPerPage = 20,
     pageNumber = 1,
-    author
+    author,
+    title,
+    article_type_article,
+    article_type_advertisement,
   }) {      
     const searchQuery = createCloudsearchQuery({ 
-      q: q, 
+      article_text: article_text, 
       resultsPerPage: resultsPerPage, 
       pageNumber: pageNumber, 
       highlight: 'article_text',
       year_start: year_start,
       year_end: year_end,
       author: author,
+      title: title,
+      article_type_article: article_type_article,
+      article_type_advertisement: article_type_advertisement,
     });
 
     if(!searchQuery){

--- a/src/pages/CloudsearchView.jsx
+++ b/src/pages/CloudsearchView.jsx
@@ -249,7 +249,7 @@ class CloudsearchView extends React.Component {
         const resultsSize = e.hits.found - resultsPerPage;
         const results = hits.map(function(hit){
           const replace_text = {
-            "\\.\\.\\.":'...<br><br>...',
+            "\\.\\.\\.":'...<br>...',
             "<em>":"<mark>",
             "</em>":"</mark>"
           }
@@ -260,8 +260,12 @@ class CloudsearchView extends React.Component {
             }
             return replace_text[matched];
           });
+          console.log(e);
           const text = '...' + highlighted_text + '...';
           const title = hit.fields.title;
+          const subtitle = hit.fields.subtitle;
+          const author = hit.fields.author;
+          const author_title = hit.fields.author_title;
           const type = hit.fields.article_type;
           const matchCount = 100; // idk what this is yet
           const raw_id = hit.id;
@@ -269,7 +273,10 @@ class CloudsearchView extends React.Component {
           const date = moment(new Date(hit.fields.publish_date));
           return {
             text: [text],
+            subtitle: subtitle,
             title: title,
+            author: author,
+            author_title: author_title,
             type: type,
             matchCount: matchCount,
             id: id,

--- a/src/pages/CloudsearchView.jsx
+++ b/src/pages/CloudsearchView.jsx
@@ -173,7 +173,6 @@ class CloudsearchView extends React.Component {
         "ui:widget": "hidden"
       },
     };
-
     const pagination = (
       <>
         <Pagination
@@ -184,7 +183,7 @@ class CloudsearchView extends React.Component {
           total={
             Math.min(
               this.state.searchResultsSize,
-              9980
+              10000
             ) /* cloudsearch needs cursor to fetch results past result number 10000. (todo: implement cursor lol) */
           }
           showTotal={(total, range) =>
@@ -286,7 +285,7 @@ class CloudsearchView extends React.Component {
       .then(e => {
         // TODO: handle error
         const hits = e.hits.hit;
-        const resultsSize = e.hits.found - resultsPerPage;
+        const resultsSize = e.hits.found;
         const results = hits.map(function(hit){
           const replace_text = {
             "\\.\\.\\.":'...<br>...',

--- a/src/pages/CloudsearchView.jsx
+++ b/src/pages/CloudsearchView.jsx
@@ -101,6 +101,9 @@ class CloudsearchView extends React.Component {
           type: "string",
           default: DEFAULTS_FORM_DATA.author
         },
+        // author_title: {
+
+        // },
         year_start: {
           title: "From",
           type: "number",

--- a/src/pages/CloudsearchView.jsx
+++ b/src/pages/CloudsearchView.jsx
@@ -38,7 +38,7 @@ class CloudsearchView extends React.Component {
   }
 
   startSearchFromQuery() {
-    let { article_text, author, title, article_type_article, article_type_advertisement, year_start, year_end, page, pagelen } = queryString.parse(
+    let { article_text, author, title, article_type_article, article_type_advertisement, year_start, year_end, page, pagelen, author_title } = queryString.parse(
       window.location.search
     );
     // https://stackoverflow.com/a/4564199/2603230
@@ -60,6 +60,7 @@ class CloudsearchView extends React.Component {
         title,
         article_type_article,
         article_type_advertisement,
+        author_title,
       }
     });
 
@@ -76,6 +77,7 @@ class CloudsearchView extends React.Component {
       title,
       article_type_article,
       article_type_advertisement,
+      author_title,
     });
   }
 
@@ -101,9 +103,19 @@ class CloudsearchView extends React.Component {
           type: "string",
           default: DEFAULTS_FORM_DATA.author
         },
-        // author_title: {
-
-        // },
+        author_title: {
+          title: "Author Title",
+          enum: ['SENIOR STAFF WRITER', 'STAFF WRITER', 'DESK EDITOR', 
+          'MANAGING EDITOR', 'EDITOR IN CHIEF', 'DEPUTY EDITOR', 'EXECUTIVE EDITOR', 'STAFF', 
+          'ASSU President', 'ASSU Parlimentarian', 'STAFF FOOTBALL WRITERS', 'FASHION COLUMNIST', 
+          'FOOTBALL EDITOR', 'ARTS EDITOR', 'FOOD EDITOR', 'FOOD DINING EDITOR', 'OPINIONS DESK',
+          'FOOD DRUNK EDITOR', 'FELLOW', 'DAILY INTERN', 'CONTRIBUTING EDITOR', 'MANAGING WRITER',
+          'GUEST COLUMNIST', 'SEX GODDESS', 'GUEST COLUMNISTS', 'EDITORIAL STAKE', 'CONTRIBUTING YANKEE',
+          'SPECIAL CONTRIBUTOR', 'EDITORIAL BOARD', 'CONTRIBUTING WRITER', 'EDITORIAL STAFF', 'FILM CRITIC',
+          'HEALTH EDITOR', 'ASSHOLE', 'INTERMISSION', 'NEWS EDITOR', 'CLASS PRESIDENT', 'ASSOCIATED PRESS',
+          'AP SPORTS WRITER', 'AP BASEBALL WRITER', 'WEEKLY COLUMNIST', 'HEALTH COLUMNIST', 'ASSOCIATED EDITOR',
+          'ASSOCIATE EDITOR', 'SPORTS EDITOR', 'EDITOR THE DAILY', ]
+        },
         year_start: {
           title: "From",
           type: "number",
@@ -240,6 +252,7 @@ class CloudsearchView extends React.Component {
     title,
     article_type_article,
     article_type_advertisement,
+    author_title,
   }) {      
     const searchQuery = createCloudsearchQuery({ 
       article_text: article_text, 
@@ -252,6 +265,7 @@ class CloudsearchView extends React.Component {
       title: title,
       article_type_article: article_type_article,
       article_type_advertisement: article_type_advertisement,
+      author_title: author_title,
     });
 
     if(!searchQuery){

--- a/src/pages/CloudsearchView.jsx
+++ b/src/pages/CloudsearchView.jsx
@@ -1,29 +1,17 @@
 import "rc-pagination/assets/index.css";
 
 import { STRINGS, getDatePath } from "../helpers/constants";
+import { createCloudsearchQuery, getCloudsearchURL } from "../helpers/search";
 
 import Form from "react-jsonschema-form";
 import Loading from "./components/Loading";
 import Pagination from "rc-pagination";
 import React from "react";
 import SearchResults from "./components/SearchResults";
-import { createCloudsearchQuery } from "../helpers/search";
 import fetch from "cross-fetch";
 import localeInfo from "rc-pagination/lib/locale/en_US";
 import moment from "moment";
 import queryString from "query-string";
-
-export function sendCloudsearchFromForm(event, history) {
-        const searchKeyword = event.target.elements.searchKeyword.value;
-        if (searchKeyword) {
-            history.push(getCloudsearchURL({ q: searchKeyword }));
-        }
-        event.preventDefault();
-  }
-
-export function getCloudsearchURL(formData) {
-    return STRINGS.ROUTE_CLOUDSEARCH_PREFIX + "?" + queryString.stringify(formData);
-}
 
 export const DEFAULTS_FORM_DATA = {
   q: "",

--- a/src/pages/CloudsearchView.jsx
+++ b/src/pages/CloudsearchView.jsx
@@ -114,7 +114,7 @@ class CloudsearchView extends React.Component {
           'SPECIAL CONTRIBUTOR', 'EDITORIAL BOARD', 'CONTRIBUTING WRITER', 'EDITORIAL STAFF', 'FILM CRITIC',
           'HEALTH EDITOR', 'ASSHOLE', 'INTERMISSION', 'NEWS EDITOR', 'CLASS PRESIDENT', 'ASSOCIATED PRESS',
           'AP SPORTS WRITER', 'AP BASEBALL WRITER', 'WEEKLY COLUMNIST', 'HEALTH COLUMNIST', 'ASSOCIATED EDITOR',
-          'ASSOCIATE EDITOR', 'SPORTS EDITOR', 'EDITOR THE DAILY', ]
+          'ASSOCIATE EDITOR', 'SPORTS EDITOR', 'EDITOR THE DAILY', ],
         },
         year_start: {
           title: "From",
@@ -161,6 +161,9 @@ class CloudsearchView extends React.Component {
         "ui:placeholder": "Leave empty to search all"
       },
       title: {
+        "ui:placeholder": "Leave empty to search all"
+      },
+      author_title: {
         "ui:placeholder": "Leave empty to search all"
       },
       page: {

--- a/src/pages/CloudsearchView.jsx
+++ b/src/pages/CloudsearchView.jsx
@@ -1,13 +1,12 @@
 import "rc-pagination/assets/index.css";
 
-import { IoIosPaper, IoMdMegaphone } from "react-icons/io";
 import { STRINGS, getDatePath } from "../helpers/constants";
 
 import Form from "react-jsonschema-form";
-import { Link } from "react-router-dom";
 import Loading from "./components/Loading";
 import Pagination from "rc-pagination";
 import React from "react";
+import SearchResults from "./components/SearchResults";
 import { createCloudsearchQuery } from "../helpers/search";
 import fetch from "cross-fetch";
 import localeInfo from "rc-pagination/lib/locale/en_US";
@@ -205,38 +204,8 @@ class CloudsearchView extends React.Component {
           ) : this.state.searchResults.length ? (
             <div className="SearchResultAllResultsContent">
               <div className="EachResult SearchPagination">{pagination}</div>
-              {this.state.searchResults.map((eachResult, index) => (
-                <div className="EachResult" key={index}>
-                  <h4 className="EachResultTitle">
-                    {eachResult.type === "advertisement" ? (
-                      <IoMdMegaphone />
-                    ) : (
-                      <IoIosPaper />
-                    )}
-                    <span>
-                      <Link
-                        to={getDatePath(eachResult.date, {
-                          section: eachResult.id
-                        })}
-                      >
-                        {eachResult.title}
-                      </Link>
-                    </span>
-                    <span className="EachResultDate">
-                      {eachResult.date.format("MMMM DD, YYYY")}
-                    </span>
-                  </h4>
-                  <div className="EachResultTexts">
-                    {eachResult.text.map((eachText, textIndex) => (
-                      <p
-                        className="EachResultEachText"
-                        key={textIndex}
-                        dangerouslySetInnerHTML={{ __html: eachText }}
-                      />
-                    ))}
-                  </div>
-                </div>
-              ))}
+              <SearchResults searchResults={this.state.searchResults} getDatePath={getDatePath} />
+              
               {/* TODO: add a notice with `EachResult` class here to notice the user that there query has return >1000 results and only first 1000 can be shown and please limit query */}
               <div className="EachResult SearchPagination">{pagination}</div>
             </div>

--- a/src/pages/components/CloudsearchWidget.jsx
+++ b/src/pages/components/CloudsearchWidget.jsx
@@ -1,6 +1,6 @@
 import { IoIosSearch } from 'react-icons/io';
 import React from 'react';
-import { sendCloudsearchFromForm } from '../CloudsearchView';
+import { sendCloudsearchFromForm } from '../../helpers/search';
 import { withRouter } from "react-router-dom";
 
 const CloudsearchWidget = ({history}) => {

--- a/src/pages/components/SearchResults.js
+++ b/src/pages/components/SearchResults.js
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom';
 import React from 'react';
 
 const SearchResult = ({eachResult, getDatePath}) => {
-    let author_data = DEFAULTS_FORM_DATA;
+    let author_data = {...DEFAULTS_FORM_DATA};
     if(eachResult.author){
         author_data.author = eachResult.author;
     }

--- a/src/pages/components/SearchResults.js
+++ b/src/pages/components/SearchResults.js
@@ -9,8 +9,12 @@ const SearchResult = ({eachResult, getDatePath}) => {
     if(eachResult.author){
         author_data.author = eachResult.author;
     }
-    let year_data = {...DEFAULTS_FORM_DATA};
-    year_data.year_start = eachResult.date.year();
+    let author_title_data = {...DEFAULTS_FORM_DATA};
+    if(eachResult.author_title){
+        author_title_data.author_title = eachResult.author_title;
+    }
+    let year_data = {...DEFAULTS_FORM_DATA}; 
+    year_data.year_start = eachResult.date.year(); //just link to current year, because we can't search for specific days (yet)
     year_data.year_end = eachResult.date.year();
 
     return (
@@ -37,7 +41,7 @@ const SearchResult = ({eachResult, getDatePath}) => {
             {eachResult.subtitle &&
                 <h5 className="EachResultSubtitle">{eachResult.subtitle}</h5>}
             {eachResult.author &&
-                <h5 className="EachResultAuthor">By <Link to={getCloudsearchURL(author_data)}>{eachResult.author.replace(/^\s+|\s+$/g, '')}</Link>{eachResult.author_title && `, ${eachResult.author_title}`}</h5>}
+                <h5 className="EachResultAuthor">By <Link to={getCloudsearchURL(author_data)}>{eachResult.author.replace(/^\s+|\s+$/g, '')}</Link>{eachResult.author_title && <Link to={getCloudsearchURL(author_title_data)}>{`, ${eachResult.author_title}`}</Link>}</h5>}
             <div className="EachResultTexts">
                 {eachResult.text.map((eachText, textIndex) => (
                 <p

--- a/src/pages/components/SearchResults.js
+++ b/src/pages/components/SearchResults.js
@@ -9,6 +9,10 @@ const SearchResult = ({eachResult, getDatePath}) => {
     if(eachResult.author){
         author_data.author = eachResult.author;
     }
+    let year_data = {...DEFAULTS_FORM_DATA};
+    year_data.year_start = eachResult.date.year();
+    year_data.year_end = eachResult.date.year();
+
     return (
         <div className="EachResult">
             <h4 className="EachResultTitle">
@@ -27,7 +31,7 @@ const SearchResult = ({eachResult, getDatePath}) => {
                 </Link>
                 </span>
                 <span className="EachResultDate">
-                {eachResult.date.format("MMMM DD, YYYY")}
+                    <Link to={getCloudsearchURL(year_data)}>{eachResult.date.format("MMMM DD, YYYY")}</Link>
                 </span>
             </h4>
             {eachResult.subtitle &&

--- a/src/pages/components/SearchResults.js
+++ b/src/pages/components/SearchResults.js
@@ -1,9 +1,14 @@
+import { DEFAULTS_FORM_DATA, getCloudsearchURL } from '../../helpers/search';
 import { IoIosPaper, IoMdMegaphone } from 'react-icons/io';
 
 import { Link } from 'react-router-dom';
 import React from 'react';
 
 const SearchResult = ({eachResult, getDatePath}) => {
+    let author_data = DEFAULTS_FORM_DATA;
+    if(eachResult.author){
+        author_data.author = eachResult.author;
+    }
     return (
         <div className="EachResult">
             <h4 className="EachResultTitle">
@@ -28,7 +33,7 @@ const SearchResult = ({eachResult, getDatePath}) => {
             {eachResult.subtitle &&
                 <h5 className="EachResultSubtitle">{eachResult.subtitle}</h5>}
             {eachResult.author &&
-                <h5 className="EachResultAuthor">By {eachResult.author.replace(/^\s+|\s+$/g, '')}{eachResult.author_title && `, ${eachResult.author_title}`}</h5>}
+                <h5 className="EachResultAuthor">By <Link to={getCloudsearchURL(author_data)}>{eachResult.author.replace(/^\s+|\s+$/g, '')}</Link>{eachResult.author_title && `, ${eachResult.author_title}`}</h5>}
             <div className="EachResultTexts">
                 {eachResult.text.map((eachText, textIndex) => (
                 <p

--- a/src/pages/components/SearchResults.js
+++ b/src/pages/components/SearchResults.js
@@ -3,41 +3,51 @@ import { IoIosPaper, IoMdMegaphone } from 'react-icons/io';
 import { Link } from 'react-router-dom';
 import React from 'react';
 
+const SearchResult = ({eachResult, getDatePath}) => {
+    return (
+        <div className="EachResult">
+            <h4 className="EachResultTitle">
+                {eachResult.type === "advertisement" ? (
+                <IoMdMegaphone />
+                ) : (
+                <IoIosPaper />
+                )}
+                <span>
+                <Link
+                    to={getDatePath(eachResult.date, {
+                    section: eachResult.id
+                    })}
+                >
+                    {eachResult.title}
+                </Link>
+                </span>
+                <span className="EachResultDate">
+                {eachResult.date.format("MMMM DD, YYYY")}
+                </span>
+            </h4>
+            {eachResult.subtitle &&
+                <h5 className="EachResultSubtitle">{eachResult.subtitle}</h5>}
+            {eachResult.author &&
+                <h5 className="EachResultAuthor">By {eachResult.author.replace(/^\s+|\s+$/g, '')}{eachResult.author_title && `, ${eachResult.author_title}`}</h5>}
+            <div className="EachResultTexts">
+                {eachResult.text.map((eachText, textIndex) => (
+                <p
+                    className="EachResultEachText"
+                    key={textIndex}
+                    dangerouslySetInnerHTML={{ __html: eachText }}
+                />
+                ))}
+            </div>
+        </div>
+    );
+}
+
 const SearchResults = ({searchResults, getDatePath}) => {
     return ( 
         <div>
-            {searchResults.map((eachResult, index) => (
-                    <div className="EachResult" key={index}>
-                    <h4 className="EachResultTitle">
-                        {eachResult.type === "advertisement" ? (
-                        <IoMdMegaphone />
-                        ) : (
-                        <IoIosPaper />
-                        )}
-                        <span>
-                        <Link
-                            to={getDatePath(eachResult.date, {
-                            section: eachResult.id
-                            })}
-                        >
-                            {eachResult.title}
-                        </Link>
-                        </span>
-                        <span className="EachResultDate">
-                        {eachResult.date.format("MMMM DD, YYYY")}
-                        </span>
-                    </h4>
-                    <div className="EachResultTexts">
-                        {eachResult.text.map((eachText, textIndex) => (
-                        <p
-                            className="EachResultEachText"
-                            key={textIndex}
-                            dangerouslySetInnerHTML={{ __html: eachText }}
-                        />
-                        ))}
-                    </div>
-                    </div>
-                ))}
+            {searchResults.map((eachResult) => (
+                <SearchResult key={eachResult.date.format() + eachResult.id} eachResult={eachResult} getDatePath={getDatePath} />
+            ))}
         </div> 
     );
 }

--- a/src/pages/components/SearchResults.js
+++ b/src/pages/components/SearchResults.js
@@ -1,0 +1,45 @@
+import { IoIosPaper, IoMdMegaphone } from 'react-icons/io';
+
+import { Link } from 'react-router-dom';
+import React from 'react';
+
+const SearchResults = ({searchResults, getDatePath}) => {
+    return ( 
+        <div>
+            {searchResults.map((eachResult, index) => (
+                    <div className="EachResult" key={index}>
+                    <h4 className="EachResultTitle">
+                        {eachResult.type === "advertisement" ? (
+                        <IoMdMegaphone />
+                        ) : (
+                        <IoIosPaper />
+                        )}
+                        <span>
+                        <Link
+                            to={getDatePath(eachResult.date, {
+                            section: eachResult.id
+                            })}
+                        >
+                            {eachResult.title}
+                        </Link>
+                        </span>
+                        <span className="EachResultDate">
+                        {eachResult.date.format("MMMM DD, YYYY")}
+                        </span>
+                    </h4>
+                    <div className="EachResultTexts">
+                        {eachResult.text.map((eachText, textIndex) => (
+                        <p
+                            className="EachResultEachText"
+                            key={textIndex}
+                            dangerouslySetInnerHTML={{ __html: eachText }}
+                        />
+                        ))}
+                    </div>
+                    </div>
+                ))}
+        </div> 
+    );
+}
+ 
+export default SearchResults;

--- a/src/pages/components/TSDNavbar.jsx
+++ b/src/pages/components/TSDNavbar.jsx
@@ -1,6 +1,7 @@
-import React from "react";
 import { Link, withRouter } from "react-router-dom";
-import { Navbar, Nav } from "react-bootstrap";
+import { Nav, Navbar } from "react-bootstrap";
+
+import React from "react";
 import ReactGA from "react-ga";
 import { STRINGS } from "../../helpers/constants";
 
@@ -29,7 +30,7 @@ class TSDNavbar extends React.Component {
         Acknowledgements: STRINGS.ROUTE_ACKNOWLEDGEMENTS
       },
       right: {
-        Search: STRINGS.ROUTE_SEARCH_PREFIX
+        Search: STRINGS.ROUTE_CLOUDSEARCH_PREFIX
       }
     };
     let navLinks = {};
@@ -37,7 +38,7 @@ class TSDNavbar extends React.Component {
       navLinks[navType] = [];
       for (let navItemName in navItems[navType]) {
         const navItemPathname = navItems[navType][navItemName];
-
+        console.log("pathname:", navItemPathname)
         let classNames = "nav-link";
         if (this.props.location.pathname === navItemPathname) {
           classNames += " active";

--- a/src/pages/components/TSDNavbar.jsx
+++ b/src/pages/components/TSDNavbar.jsx
@@ -21,8 +21,6 @@ class TSDNavbar extends React.Component {
   }
 
   render() {
-    console.log(this.props.location);
-
     let navItems = {
       left: {
         Home: STRINGS.ROUTE_ROOT,
@@ -38,7 +36,6 @@ class TSDNavbar extends React.Component {
       navLinks[navType] = [];
       for (let navItemName in navItems[navType]) {
         const navItemPathname = navItems[navType][navItemName];
-        console.log("pathname:", navItemPathname)
         let classNames = "nav-link";
         if (this.props.location.pathname === navItemPathname) {
           classNames += " active";

--- a/src/pages/sass/SearchView.scss
+++ b/src/pages/sass/SearchView.scss
@@ -136,6 +136,17 @@
     margin-left: auto;
   }
 }
+.EachResultSubtitle {
+  // margin-left: 30px; 
+  color: $color__clay;
+  vertical-align: middle;
+}
+.EachResultAuthor {
+  vertical-align: middle;
+  .EarchResultAuthorTitle {
+
+  }
+}
 .EachResultEachText:last-of-type {
   margin-bottom: 0;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7023,6 +7023,11 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+lucene@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/lucene/-/lucene-2.1.1.tgz#e710cc123b214eaf72a4c5f1da06943c0af44d86"
+  integrity sha512-l0qCX+pgXEZh/7sYQNG+vzhOIFRPjlJJkQ/irk9n7Ak3d+1MrU6F7IV31KILwFkUn153oLK8a2AIt48DzLdVPg==
+
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"


### PR DESCRIPTION
Cloudsearch searching can now be more specific. #19 #56 #57 #64 #65 and part of #37 ("Be able to search everything with an empty query")

One limitation is that the link from dates just links to the year of the date (and not month/day, since we can't query by those, yet). 

A issue (I think this is a problem with cloudsearch somehow, and maybe out of our control)  is some queries don't return correct results. For example, if you search "Tiger Woods" in article text, you see that "Kabir Sawhney" is an author, but if you search "Tiger Woods" in the article text field, in combination with "Kabir Sawhney" in the author field, you won't get any results.

