### PR TITLE
enabled more specific date choices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ lib
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.next

--- a/src/helpers/search.js
+++ b/src/helpers/search.js
@@ -4,8 +4,8 @@ import queryString from "query-string";
 
 export const DEFAULTS_FORM_DATA = {
     article_text: "",
-    year_start: 1892,
-    year_end: 2014,
+    start_date: "1892-09-19",
+    end_date: "2014-06-13",
     page: 1,
     pagelen: 20,
     author: undefined,
@@ -36,8 +36,8 @@ export function createCloudsearchQuery(query){
         if(query.author){
             lucene_string += add_and_lucene_string(lucene_string, 'author', '"' + query.author + '"');
         }
-        if(query.year_start && query.year_end){
-            lucene_string += add_and_lucene_string(lucene_string, 'publish_date', `[${query.year_start}-01-01T12:00:00Z TO ${query.year_end+1}-01-02T12:00:00Z]`);
+        if(query.start_date && query.end_date){
+            lucene_string += add_and_lucene_string(lucene_string, 'publish_date', `[${query.start_date}T00:00:00Z TO ${query.end_date}T23:59:59Z]`);
         }
         if(query.title){
             lucene_string += add_and_lucene_string(lucene_string, 'title', '"' + query.title + '"');
@@ -68,6 +68,8 @@ export function createCloudsearchQuery(query){
         if(query.highlight === 'article_text'){
             query_obj = {...query_obj, "highlight.article_text": "{format:'html',max_phrases:5}"};
         }
+
+        console.log(query_obj);
         return queryString.stringify(query_obj);
     } catch(error){
         return undefined;

--- a/src/pages/components/SearchResults.js
+++ b/src/pages/components/SearchResults.js
@@ -14,8 +14,8 @@ const SearchResult = ({eachResult, getDatePath}) => {
         author_title_data.author_title = eachResult.author_title;
     }
     let year_data = {...DEFAULTS_FORM_DATA}; 
-    year_data.year_start = eachResult.date.year(); //just link to current year, because we can't search for specific days (yet)
-    year_data.year_end = eachResult.date.year();
+    year_data.start_date = eachResult.date.format("YYYY-MM-DD");
+    year_data.end_date = eachResult.date.format("YYYY-MM-DD");
 
     return (
         <div className="EachResult">


### PR DESCRIPTION
## Reasons for making this change

Previously, could only search dates by year. Now can do by year, month, day. Also updated the date link in each search result to link to all articles from that day.

## Screenshots

<img width="282" alt="Screen Shot 2020-05-22 at 9 24 26 PM" src="https://user-images.githubusercontent.com/46544566/82718775-a06e2800-9c72-11ea-8bea-5548747dde3b.png">
