### PR TITLE
fix(today-in-history): no more document undefined error

### DIFF
--- a/components/components/TodayInHistory.js
+++ b/components/components/TodayInHistory.js
@@ -1,7 +1,6 @@
 import Link from "next/link";
 import Loading from "../components/Loading";
 import NotFound from "../NotFound";
-import OpenSeadragon from "openseadragon";
 import React from 'react';
 import { fetchPaper } from "../../helpers/papers";
 import { getDatePath } from "../../helpers/constants";
@@ -69,7 +68,8 @@ class TodayPaperView extends React.Component {
         }
         this.setState({ loading: false });
 
-        if(this.state.yearsLeft.length > 0){
+        if(this.state.yearsLeft.length > 0 && typeof document !== 'undefined'){
+            const OpenSeadragon = require("openseadragon");
             let viewer = new OpenSeadragon({
                 id: "paper-openseadragon",
                 prefixUrl: "https://openseadragon.github.io/openseadragon/images/", // TODO: change to local path


### PR DESCRIPTION
## Reasons for making this change

I screwed up & merged broken nextjs stuff into master (wasn't deployed though). This fixes the bug. The bug was that openseadragon requires certain properties are not undefined (I think https://github.com/TheStanfordDaily/archives-web/commit/932cfce33c53addf6a2607c341717162529e9023 also refers to this issue). The reason I couldn't use the same fix as https://github.com/TheStanfordDaily/archives-web/commit/932cfce33c53addf6a2607c341717162529e9023 is because it would cause other parts of the site, like the issue pages, to break. 
