### PR TITLE
fix(archives-text): master -> main

### DIFF
--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -8,7 +8,7 @@ export const STRINGS = {
   FILE_SERVER_URL: "https://tiles.archives.stanforddaily.com/",
   IMAGE_SERVER_URL: "https://tiles.archives.stanforddaily.com/",
   CLOUDSEARCH_SEARCH_URL: "https://ehabp6fuc5.execute-api.us-east-1.amazonaws.com/prod",
-  SECTION_CONTENT_SERVER_URL: "https://raw.githubusercontent.com/TheStanfordDaily/archives-text/master/",
+  SECTION_CONTENT_SERVER_URL: "https://raw.githubusercontent.com/TheStanfordDaily/archives-text/main/",
   ROUTE_ROOT: "/",
   ROUTE_CALENDAR: "/calendar",
   ROUTE_ACKNOWLEDGEMENTS: "/acknowledgements",


### PR DESCRIPTION
## Reasons for making this change

archives-text branch master renamed to main, updating to reflect here. Note: still need to deploy after merging. 