### PR TITLE
Automatically deploy to archives.stanforddaily.com from main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,22 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request 
+# events but only for the main branch
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - run: yarn install
+    - run: yarn build
+    - run: yarn run deploy
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Setting up a similar auto-deploy to the main website (https://github.com/TheStanfordDaily/stanforddaily/blob/main/.github/workflows/deploy.yml). I added two secrets to this repo, AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.
